### PR TITLE
for some reason generate() is called twice

### DIFF
--- a/src/LetterAvatar.php
+++ b/src/LetterAvatar.php
@@ -116,6 +116,7 @@ class LetterAvatar
         $words = $this->break_words($this->name);
 
         $number_of_word = 1;
+        $this->name_initials = '';
         foreach ($words as $word) {
 
             if ($number_of_word > 2)


### PR DESCRIPTION
when it happens, the initials get doubled up, so 4 letters instead of 2.

this fixes the effect, but would be interested to know why generate() is called twice...

my code is simply:

```
echo new LetterAvatar('Hello World');
```