### PR TITLE
Fixes notice when called with only a firstname

### DIFF
--- a/src/LetterAvatar.php
+++ b/src/LetterAvatar.php
@@ -137,7 +137,7 @@ class LetterAvatar
             return '';
         }
 
-        $secondLetter = $nameParts[1] ? $this->getFirstLetter($nameParts[1]) : '';
+        $secondLetter = isset($nameParts[1]) ? $this->getFirstLetter($nameParts[1]) : '';
 
         return $this->getFirstLetter($nameParts[0]) . $secondLetter;
 


### PR DESCRIPTION
This fixes the following notices when call with with something like `new LetterAvatar('Firstname', 'square', 64)`
Notice: Undefined offset: 1 in ../vendor/yohang88/letter-avatar/src/LetterAvatar.php on line 140