### PR TITLE
Publicize some potentially desired methods

### DIFF
--- a/src/LetterAvatar.php
+++ b/src/LetterAvatar.php
@@ -86,7 +86,7 @@ class LetterAvatar
     /**
      * @param string $name
      */
-    private function setName(string $name)
+    public function setName(string $name)
     {
         $this->name = $name;
     }
@@ -103,7 +103,7 @@ class LetterAvatar
     /**
      * @param string $shape
      */
-    private function setShape(string $shape)
+    public function setShape(string $shape)
     {
         $this->shape = $shape;
     }
@@ -112,7 +112,7 @@ class LetterAvatar
     /**
      * @param int $size
      */
-    private function setSize(int $size)
+    public function setSize(int $size)
     {
         $this->size = $size;
     }
@@ -153,7 +153,7 @@ class LetterAvatar
      * @param string $name
      * @return string
      */
-    private function getInitials(string $name): string
+    public function getInitials(string $name): string
     {
         $nameParts = $this->break_name($name);
 
@@ -171,7 +171,7 @@ class LetterAvatar
      * @param string $word
      * @return string
      */
-    private function getFirstLetter(string $word): string
+    public function getFirstLetter(string $word): string
     {
         return mb_strtoupper(trim(mb_substr($word, 0, 1, 'UTF-8')));
     }


### PR DESCRIPTION
As the image is never rendered until explicitly requested either via `saveAs` or `__toString()` it made no sense to make potentially desired methods private

This PR just simply opens those few up